### PR TITLE
fixed mode color for searchbar magnifier logo

### DIFF
--- a/src/components/searchbar/searchBar.css
+++ b/src/components/searchbar/searchBar.css
@@ -26,6 +26,11 @@
 .SearchBar svg {
   width: 1rem;
   color: var(--foreground);
+  stroke: var(--foreground);
+}
+
+.SearchBar svg path {
+  stroke: var(--foreground);
 }
 
 .SearchBar button {

--- a/src/components/searchbar/searchBar.css
+++ b/src/components/searchbar/searchBar.css
@@ -26,7 +26,6 @@
 .SearchBar svg {
   width: 1rem;
   color: var(--foreground);
-  stroke: var(--foreground);
 }
 
 .SearchBar svg path {


### PR DESCRIPTION
The magnifier icon essentially disappeared in light mode due to low contrast. Added CSS to fix that.